### PR TITLE
Don't use regex in swanson script

### DIFF
--- a/scripts/swanson.py
+++ b/scripts/swanson.py
@@ -9,7 +9,6 @@ with a random quote from Ron Swanson of Parks & Recs.
 import asyncio
 import hangups
 import logging
-import re
 import requests
 
 
@@ -17,11 +16,12 @@ logger = logging.getLogger('hangbot.scripts.swanson')
 
 
 API_URL = 'http://ron-swanson-quotes.herokuapp.com/v2/quotes'
-MESSAGE_REGEX = re.compile(r'^hangbot swanson me$', re.IGNORECASE)
+COMMAND = 'hangbot swanson me'
 
 
 async def process_message(client, conversation, message_event):
-    if MESSAGE_REGEX.match(message_event.text):
+    if message_event.text and \
+            message_event.text.strip().lower() == COMMAND:
         loop = asyncio.get_event_loop()
         response = await loop.run_in_executor(None, requests.get, API_URL)
         quote = response.json()[0]


### PR DESCRIPTION
It's not necessary, and it obfuscates the core command.

@tnterdan: Please take a look when you have the chance. Super low priority.